### PR TITLE
Use multi part form to upload content

### DIFF
--- a/simple-nokogiri/connect.rb
+++ b/simple-nokogiri/connect.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-def build_request(https, session, name)
+def build_request(https, session, name, form_file=nil)
   args = { name: name }
   args[:session] = session unless session.nil?
   builder = Nokogiri::XML::Builder.new do |xml|
@@ -12,9 +12,17 @@ def build_request(https, session, name)
   end
 
   request = Net::HTTP::Post.new("__mflux_svc__")
-  request.body = builder.to_xml
-  request["Content-Type"] = "text/xml; charset=utf-8"
-
+  if form_file.nil?
+    request["Content-Type"] = "text/xml; charset=utf-8"
+    request.body = builder.to_xml
+  else
+    request["Content-Type"] = 'multipart/form-data'
+    request.set_form({ "request" => builder.to_xml, 
+                   "nb-data-attachments" => "1", 
+                   "file_0" => form_file},
+                   "multipart/form-data",
+                   "charset" => "UTF-8")
+  end  
   https.request(request)
 end
 

--- a/simple-nokogiri/create_asset.rb
+++ b/simple-nokogiri/create_asset.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+require 'date'
+require 'net/http'
+require 'yaml'
+require 'byebug'
+require './connect'
+
+config = YAML.load_file('config.yaml').transform_keys(&:to_sym)
+https = Net::HTTP.new(config[:mf_host], config[:mf_port])
+https.use_ssl = true
+
+if ARGV.empty?
+  puts 'usage: ruby create_asset.rb [full file path]'
+  exit 1
+end
+
+path = ARGV[0]
+unless File.exist?(path)
+  puts 'file #{path} does not exists'
+  exit 1
+end
+
+session = login(https, config)
+
+extension = File.extname(path)
+input_name = File.basename(path, extension)
+
+name = "#{input_name}_#{Time.now.to_i}.#{extension}"
+
+response = build_request(https, session, 'asset.create',  File.open(path)) do |xml|
+  xml.args do
+    xml.meta do
+      xml.send("mf-name") do
+        xml.name name
+      end
+    end
+    xml.name name
+    xml.namespace "test"
+  end
+end
+doc = Nokogiri::XML.parse(response.body)
+puts doc
+
+response = logoff(https)


### PR DESCRIPTION
refs #5

This uploads any file on your local desktop to MediaFlux in the test namespace.