### PR TITLE
Allow updating of mf-document metadata

### DIFF
--- a/simple-nokogiri/update_metadata.rb
+++ b/simple-nokogiri/update_metadata.rb
@@ -20,7 +20,8 @@ session = login(https, config)
 ids = ARGV[0].split(',')
 metadata_field = ARGV[1]
 metadata_value = ARGV[2]
-
+# Note: Adding metadata to the collection in this way did not propagate to the members. 
+# Maybe I have something not set quite right in the collection, or maybe we need a different update command.
 response = build_request(https, session, 'asset.set') do |xml|
   xml.args do
     ids.each { |id| xml.id id }

--- a/simple-nokogiri/update_metadata.rb
+++ b/simple-nokogiri/update_metadata.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+require 'net/http'
+require 'yaml'
+require 'byebug'
+require './connect'
+
+config = YAML.load_file('config.yaml').transform_keys(&:to_sym)
+https = Net::HTTP.new(config[:mf_host], config[:mf_port])
+https.use_ssl = true
+
+if ARGV.length != 3
+  puts 'usage: ruby update_metadata.rb [id] [metadata_field] [metadata_value]'
+  puts 'valid fields:subject, decription, comments, author, keyword'
+  exit 1
+end
+
+session = login(https, config)
+ids = ARGV[0].split(',')
+metadata_field = ARGV[1]
+metadata_value = ARGV[2]
+
+response = build_request(https, session, 'asset.set') do |xml|
+  xml.args do
+    ids.each { |id| xml.id id }
+    xml.meta do
+      xml.send("mf-document") do
+        xml.send( metadata_field, metadata_value)
+      end
+    end
+  end
+end
+doc = Nokogiri::XML.parse(response.body)
+puts doc
+
+response = build_request(https, session, 'asset.get') do |xml|
+  xml.args do
+    ids.each { |id| xml.id id }
+  end
+end
+doc = Nokogiri::XML.parse(response.body)
+puts doc
+
+response = logoff(https)


### PR DESCRIPTION
Adding metadata to the collection in this way did not propagate to the members. Maybe I have something not set quite right in the collection, or maybe we need a different update command.

refs #5 